### PR TITLE
refactor: only evaluate environment variables once

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -6,11 +6,19 @@ import (
 	"strings"
 )
 
-func DebugPrint(fmt_str string, v ...interface{}) {
+var debugOutput bool
+
+func init() {
 	for _, x := range os.Environ() {
 		if strings.HasPrefix(x, "REGPARSER_DEBUG=") {
-			fmt.Printf(fmt_str, v...)
-			return
+			debugOutput = true
+			break
 		}
+	}
+}
+
+func DebugPrint(fmt_str string, v ...interface{}) {
+	if debugOutput {
+		fmt.Printf(fmt_str, v...)
 	}
 }


### PR DESCRIPTION
When analyzing registry hives, analysis of environment variables from the debug output can (in rare cases) take up a majority of the time.

Only evaluate the environment variables once, at startup, to reduce this overhead.