### PR TITLE
Proposal to make Openkey case insensitive

### DIFF
--- a/cmd/regparser.go
+++ b/cmd/regparser.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 	"www.velocidex.com/golang/regparser"
@@ -33,7 +32,7 @@ func doLs() {
 		kingpin.Fatalf("Key path not found %v", *ls_command_path)
 	}
 
-	fmt.Printf("Listing key %s (%v)\n\n", path.Join(*ls_command_path, key.Name()),
+	fmt.Printf("Listing key %s (%v)\n\n", *ls_command_path,
 		key.LastWriteTime())
 
 	fmt.Printf("Subkeys:\n")

--- a/paths.go
+++ b/paths.go
@@ -18,7 +18,7 @@ func SplitComponents(path string) []string {
 		match := component_quoted_regex.FindStringSubmatch(path)
 		if len(match) > 0 {
 			if len(match[1]) > 0 {
-				components = append(components, strings.ToLower(match[1]))
+				components = append(components, match[1])
 			}
 			path = path[len(match[0]):]
 			continue
@@ -26,14 +26,14 @@ func SplitComponents(path string) []string {
 		match = component_unquoted_regex.FindStringSubmatch(path)
 		if len(match) > 0 {
 			if len(match[1]) > 0 {
-				components = append(components, strings.ToLower(match[1]))
+				components = append(components, match[1])
 			}
 			path = path[len(match[0]):]
 			continue
 		}
 
 		// This should never happen!
-		return strings.Split(strings.ToLower(path), "\\")
+		return strings.Split(path, "\\")
 	}
 	return components
 }

--- a/paths.go
+++ b/paths.go
@@ -18,7 +18,7 @@ func SplitComponents(path string) []string {
 		match := component_quoted_regex.FindStringSubmatch(path)
 		if len(match) > 0 {
 			if len(match[1]) > 0 {
-				components = append(components, match[1])
+				components = append(components, strings.ToLower(match[1]))
 			}
 			path = path[len(match[0]):]
 			continue
@@ -26,14 +26,14 @@ func SplitComponents(path string) []string {
 		match = component_unquoted_regex.FindStringSubmatch(path)
 		if len(match) > 0 {
 			if len(match[1]) > 0 {
-				components = append(components, match[1])
+				components = append(components, strings.ToLower(match[1]))
 			}
 			path = path[len(match[0]):]
 			continue
 		}
 
 		// This should never happen!
-		return strings.Split(path, "\\")
+		return strings.Split(strings.ToLower(path), "\\")
 	}
 	return components
 }

--- a/registry.go
+++ b/registry.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 )
 
 // Model a registry hive with this object.
@@ -45,6 +46,8 @@ subkey_match:
 		if component == "" {
 			continue
 		}
+
+		component = strings.ToLower(component)
 
 		for _, subkey := range nk.Subkeys() {
 			if strings.ToLower(subkey.Name()) == component {

--- a/registry.go
+++ b/registry.go
@@ -47,7 +47,7 @@ subkey_match:
 		}
 
 		for _, subkey := range nk.Subkeys() {
-			if subkey.Name() == component {
+			if strings.ToLower(subkey.Name()) == component {
 				nk = subkey
 				continue subkey_match
 			}


### PR DESCRIPTION
Hi,

this is a proposition to make `OpenKey` case insensitive.

Eg. `OpenKey("/SOFTWARE/Microsoft/Windows")` and  `OpenKey("/Software/Microsoft/Windows")` would work.

In the microsoft docs, it says that  `Key names are not case sensitive.`
https://learn.microsoft.com/en-us/windows/win32/sysinfo/structure-of-the-registry